### PR TITLE
Add initial PyTest github action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,21 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ${{github.workspace}}/build/bin/cipc-test
+
+  pytest:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade poetry
+          poetry install
+#      - name: Lint with ruff
+#        run: ruff --format=github --target-version=py38 .
+      - name: PyTest
+        run: poetry run pytest cipcc


### PR DESCRIPTION
This stage runs cipcc package tests to help avoid regressions.

Build and lint tests may be included in the future.