### PR TITLE
Complex type serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,12 @@ Depending on need, use `std::uint8_t` or `std::int8_t`_.
 
 #### Complex types
 
+* __std::deque__
+* __std::list__
+* __std::map__
 * __std::string__
-* __std::vector__
 * __std::unordered_map__
+* __std::vector__
 
 ## Internal object representation
 

--- a/cipc/serialize.cc
+++ b/cipc/serialize.cc
@@ -26,128 +26,39 @@
 
 #include <cstring>
 #include <limits>
+#include <list>
+#include <vector>
 
 namespace cipc {
-
-// --------------------------------------------------------------------
-// Integral type serialization.
-
-#define INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(TYPE) \
-    template<> \
-    std::size_t serialize<TYPE>( \
-        const TYPE& x, void* buf, std::size_t buf_size) { \
-      if (buf_size < sizeof(TYPE)) { \
-        return 0; \
-      } \
-      const typename std::make_unsigned<TYPE>::type le = host_to_le(x); \
-      memcpy(buf, &le, sizeof(le)); \
-      return sizeof(TYPE); \
-    } \
-    \
-    template<> \
-    std::size_t deserialize<TYPE>( \
-        TYPE* x, const void* buf, std::size_t buf_size) { \
-      if (buf_size < sizeof(TYPE)) { \
-        return 0; \
-      } \
-      typename std::make_unsigned<TYPE>::type le; \
-      memcpy(&le, buf, sizeof(le)); \
-      *x = le_to_host<TYPE>(le); \
-      return sizeof(TYPE); \
-    }
-
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::uint8_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::uint16_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::uint32_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::uint64_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::int8_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::int16_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::int32_t)
-INTEGRAL_TYPE_SERIALIZATION_FUNCTIONS(std::int64_t)
-
-// --------------------------------------------------------------------
-// Boolean serialization.
-
-static_assert(sizeof(bool) == 1, "Unexpected bool size.");
-
-template<>
-std::size_t serialize<bool>(const bool& x, void* buf, std::size_t buf_size) {
-  return serialize<std::uint8_t>(x, buf, buf_size);
-}
-
-template<>
-std::size_t deserialize<bool>(bool* x, const void* buf, std::size_t buf_size) {
-  return deserialize<std::uint8_t>(
-      reinterpret_cast<std::uint8_t*>(x), buf, buf_size);
-}
-
-// --------------------------------------------------------------------
-// Floating point type serialization.
-
-static_assert(
-    std::numeric_limits<float>::is_iec559,
-    "Only IEEE 754 / IEC 559 float types are currently supported.");
-static_assert(
-    std::numeric_limits<double>::is_iec559,
-    "Only IEEE 754 / IEC 559 double float types are currently supported.");
-
-#define FLOATING_POINT_TYPE_SERIALIZATION_FUNCTIONS(TYPE) \
-    template<> \
-    std::size_t serialize<TYPE>( \
-        const TYPE& x, void* buf, std::size_t buf_size) { \
-      if (buf_size < sizeof(TYPE)) { \
-        return 0; \
-      } \
-      memcpy(buf, &x, sizeof(x)); \
-      return sizeof(x); \
-    } \
-    \
-    template<> \
-    std::size_t deserialize<TYPE>( \
-        TYPE* x, const void* buf, std::size_t buf_size) { \
-      if (buf_size < sizeof(TYPE)) { \
-        return 0; \
-      } \
-      memcpy(x, buf, sizeof(TYPE)); \
-      return sizeof(TYPE); \
-    }
-
-FLOATING_POINT_TYPE_SERIALIZATION_FUNCTIONS(float)
-FLOATING_POINT_TYPE_SERIALIZATION_FUNCTIONS(double)
 
 // --------------------------------------------------------------------
 // std::string serialization.
 
 using StringSize = std::uint32_t;
 
-template<>
-std::size_t serialize<std::string>(const std::string& x, void* buf, std::size_t buf_size) {
+std::size_t serialize(const std::string& x, void* buf, std::size_t buf_size) {
   const auto size = serialized_size(x);
   if (size > buf_size) {
     return 0;
   }
-  const StringSize len = x.length();
+  const StringSize len = x.size();
   const auto len_size = serialize(len, buf, buf_size);
   buf_size -= len_size;
-  memcpy(reinterpret_cast<char*>(buf) + len_size, x.data(), x.size());
+  std::memcpy(reinterpret_cast<char*>(buf) + len_size, x.data(), x.size());
   return size;
 }
 
-template<>
-std::size_t serialized_size<std::string>(const std::string& x) {
+std::size_t serialized_size(const std::string& x) {
   return sizeof(StringSize) + x.size();
 }
 
-template<>
-std::size_t deserialize<std::string>(std::string* x, const void* buf, std::size_t buf_size) {
+std::size_t deserialize(std::string* x, const void* buf, std::size_t buf_size) {
   StringSize len;
-  const auto len_size = deserialize<StringSize>(&len, buf, buf_size);
+  const auto len_size = deserialize(&len, buf, buf_size);
   buf_size -= len_size;
   const char* start = reinterpret_cast<const char*>(buf) + len_size;
   *x = std::string(start, start + len);
   return len_size + x->size();
 }
-
-// --------------------------------------------------------------------
 
 }  // namespace cipc

--- a/cipc/serialize.h
+++ b/cipc/serialize.h
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <type_traits>
 
 #include "cipc/platform.h"
@@ -210,6 +211,8 @@ CIPC_SERIALIZATION_SPECIALIZATION(int64_t)
 CIPC_SERIALIZATION_SPECIALIZATION(bool)
 CIPC_SERIALIZATION_SPECIALIZATION(float)
 CIPC_SERIALIZATION_SPECIALIZATION(double)
+
+CIPC_SIZED_SERIALIZATION_SPECIALIZATION(std::string)
 
 }  // namespace cipc
 


### PR DESCRIPTION
This MR brings in serialization support for list-like and map-like collections, and refactors serialization
functions to use overloading rather than template specialization.